### PR TITLE
Update getbambed.R

### DIFF
--- a/package/R/getbambed.R
+++ b/package/R/getbambed.R
@@ -4,6 +4,6 @@ getbambed = function (bamdir, bedFile, sampname, projectname)
     stop("Please check the bed file directory provided. File could not be \n            found!")
   exomtarg <- read.table(bedFile, sep = "\t")
   ref <- GRanges(seqnames=exomtarg[,1],ranges=IRanges(start=exomtarg[,2], end=exomtarg[,3]))
-  ref <- sort(ref)
+  #ref <- sort(ref)
   list(bamdir = bamdir, sampname = sampname, ref = ref, projectname = projectname)
 }


### PR DESCRIPTION
This sort of ref can change the order of ref compared to the bedFile, at least in the targeted pipeline. When the gene column of bedFile is cbind to ref, it will cause the genes to be mapped incorrectly. I see no reason to sort the ref; alternatively you can sort the bedFile the same way as ref each time you read it.